### PR TITLE
Update plugins-flash.html

### DIFF
--- a/jw6-plugin-sdk/docs/plugins-flash.html
+++ b/jw6-plugin-sdk/docs/plugins-flash.html
@@ -52,14 +52,14 @@ package {
   public class HelloWorld extends Sprite implements IPlugin6 {
 
     /** Configuration options of the plugin. **/
-    private var config:Object;
+    private var config:PluginConfig;
     /** Reference to the JW Player API. **/
     private var player:IPlayer;
     /** Text field to print into. **/
     private var field:TextField;
 
     /** This function is automatically called upon load. **/
-    public function initPlugin(ply:IPlayer, cfg:Object):void {
+    public function initPlugin(ply:IPlayer, cfg:PluginConfig):void {
       player = ply;
       config = cfg;
       field = new TextField();


### PR DESCRIPTION
The config should be PluginConfig, not Object. If it is set to Object, it will fail to compile:

Error: Interface method initPlugin in namespace
com.longtailvideo.jwplayer.plugins:IPlugin is implemented with an
incompatible signature in class HelloWorld.
